### PR TITLE
feat: add remove x-frame-options header

### DIFF
--- a/manifest.ts
+++ b/manifest.ts
@@ -1,7 +1,7 @@
 export default <chrome.runtime.ManifestV3>{
   manifest_version: 3,
   name: 'Disable-CSP',
-  version: '1.0.4',
+  version: '1.0.3',
   author: `lisonge`,
   homepage_url: `https://github.com/lisonge/Disable-CSP`,
   description: `A browser extension to disable http header Content-Security-Policy and html meta Content-Security-Policy`,

--- a/manifest.ts
+++ b/manifest.ts
@@ -1,7 +1,7 @@
 export default <chrome.runtime.ManifestV3>{
   manifest_version: 3,
   name: 'Disable-CSP',
-  version: '1.0.3',
+  version: '1.0.4',
   author: `lisonge`,
   homepage_url: `https://github.com/lisonge/Disable-CSP`,
   description: `A browser extension to disable http header Content-Security-Policy and html meta Content-Security-Policy`,

--- a/src/background.ts
+++ b/src/background.ts
@@ -5,7 +5,7 @@ const REMOVE_HEADERS = [
   `content-security-policy-report-only`,
   `x-webkit-csp`,
   `x-content-security-policy`,
-];
+  `x-frame-options`,
 
 const { RuleActionType, HeaderOperation, ResourceType } =
   chrome.declarativeNetRequest;


### PR DESCRIPTION
x-frame-options与csp头中的frame-ancestors作用相同，但csp头优先级更高，在公司内网存在页面为保证兼容性同时添加了x-frame-options与csp头的frame-ancestors部分，如果只移除csp头反而导致frame页被拦截无法访问